### PR TITLE
Remove NPM dependency on docker host; Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ which continues to service requests for endpoints that have not yet been
 rebuilt.
 
 1. [How does it work?](#how-does-it-work)
-2. [Getting Started](#getting-started)
-3. [Deployment](#deployment)
-4. [Documentation](#documentation)
+2. [Requirements](#requirements)
+3. [Executing](#executing)
+4. [Deployment](#deployment)
+5. [Documentation](#documentation)
 
 ## How does it work?
 
@@ -34,43 +35,56 @@ and making it aware that they are available to receive requests. There
 exists a [services REST API](docs/service_registry.md) that is used for
 this purpose.
 
-## Getting Started
+## Requirements
 
-### OS X
+The requirements for the API Gateway greatly depend on how you plan on running it. There are two ways to run the API:
+- Natively
+- Using [Docker](https://www.docker.com/) containers
 
-We're using Docker which, luckily for you, means that getting the
-application running locally should be fairly painless. First, make sure
-that you have [Docker Compose](https://docs.docker.com/compose/install/)
-installed on your machine.
+In both cases, you will need `git` to checkout the project.
 
-If you've not used Docker before, you may need to set up some defaults:
+### Requirements for native execution
 
-```
-docker-machine create --driver virtualbox default
-docker-machine start default
-eval $(docker-machine env default)
-```
+If you want to run the API Gateway natively, you will need to install and configure:
 
-Now we're ready to actually get the application running:
+- [Node.js and npm](https://nodejs.org/)
+- [MongoDB](https://www.mongodb.org/)
+
+### Requirements for docker
+
+If you are going to use containers, you will need:
+
+- [Docker](https://www.docker.com/)
+- [docker-compose](https://docs.docker.com/compose/)
+
+## Executing
+
+Start by checking out the project from github
 
 ```
 git clone https://github.com/Vizzuality/api-gateway.git
 cd api-gateway
+```
+
+Once this is done, you can either run the application natively, or inside a docker container. 
+If you decide to run it natively, you will need to first install the required npm libraries, and the start the application:
+
+```
 npm install
-npm run develop
+./gateway.sh start
 ```
 
-In case it's not obvious (it's not), grab your Docker machine's IP:
+If, on the other hand, you plan on using docker instead, you only need to fire up the containers
 
 ```
-docker-machine ip
+./gateway.sh develop
 ```
 
-The application will be running on port 8000.
+The application will be running on port 8000 of the corresponding host (typically localhost)
 
 ## Deployment
 
-The application is deployed to Heroku, and thus is thankfull rather easy
+The application is deployed to Heroku, and thus is thankfully rather easy
 to deploy.
 
 Setup Heroku for the repository:

--- a/gateway.sh
+++ b/gateway.sh
@@ -2,16 +2,13 @@
 
 case "$1" in
     test-e2e)
-        type grunt >/dev/null 2>&1 || { echo >&2 "grunt is required but it's not installed.  Aborting."; exit 1; }
-        NODE_PATH=app/src NODE_ENV=test grunt e2eTest
+        npm run test-e2e
         ;;
     test-unit)
-        type grunt >/dev/null 2>&1 || { echo >&2 "grunt is required but it's not installed.  Aborting."; exit 1; }
-        NODE_PATH=app/src NODE_ENV=test grunt unitTest
+        npm run test-unit
         ;;
     start)
-        type node >/dev/null 2>&1 || { echo >&2 "node is required but it's not installed.  Aborting."; exit 1; }
-        NODE_PATH=app/src node app/index
+        npm start
         ;;
     develop)
         type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }

--- a/gateway.sh
+++ b/gateway.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+case "$1" in
+    test-e2e)
+        type grunt >/dev/null 2>&1 || { echo >&2 "grunt is required but it's not installed.  Aborting."; exit 1; }
+        NODE_PATH=app/src NODE_ENV=test grunt e2eTest
+        ;;
+    test-unit)
+        type grunt >/dev/null 2>&1 || { echo >&2 "grunt is required but it's not installed.  Aborting."; exit 1; }
+        NODE_PATH=app/src NODE_ENV=test grunt unitTest
+        ;;
+    start)
+        type node >/dev/null 2>&1 || { echo >&2 "node is required but it's not installed.  Aborting."; exit 1; }
+        NODE_PATH=app/src node app/index
+        ;;
+    develop)
+        type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
+        docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up
+        ;;
+    test)
+        type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
+        docker-compose -f docker-compose-test.yml run test
+        ;;
+  *)
+        echo "Usage: gateway.sh {test-e2e|test-unit|start|develop|test}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.0.0",
   "description": "Basic api gateway",
   "main": "index.js",
+  "scripts":{
+      "test-e2e": "NODE_PATH=app/src NODE_ENV=test grunt --gruntfile app/Gruntfile.js e2eTest",
+      "test-unit": "NODE_PATH=app/src NODE_ENV=test grunt --gruntfile app/Gruntfile.js unitTest",
+      "start": "NODE_PATH=app/src node app/index",
+      "test": "NODE_PATH=app/src NODE_ENV=test grunt --gruntfile app/Gruntfile.js test"
+  },
   "keywords": [
     "api-gateway",
     "microservices",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,6 @@
   "version": "1.0.0",
   "description": "Basic api gateway",
   "main": "index.js",
-  "scripts": {
-    "test-e2e": "NODE_PATH=app/src NODE_ENV=test grunt e2eTest",
-    "test-unit": "NODE_PATH=app/src NODE_ENV=test grunt unitTest",
-    "start": "NODE_PATH=app/src node app/index",
-    "develop": "docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up",
-    "test": "docker-compose -f docker-compose-test.yml run test"
-  },
-
   "keywords": [
     "api-gateway",
     "microservices",


### PR DESCRIPTION
According to the current README we currently require npm to use docker, which is silly. 
I exported the scripts defined in package.json into an equivalent gateway.sh file, which has the same actions that previously existed, without requiring npm where it doesn't make sense.

I also updated the README to reflect this, plus better identify the two running scenarios: native or docker.
