### PR TITLE
Fix old API passthrough

### DIFF
--- a/app/src/lib/restCo.js
+++ b/app/src/lib/restCo.js
@@ -66,20 +66,29 @@ module.exports =  function(config){
     delete config.uri;
     delete config.method;
 
+    // Google App Engine has issues with Host headers, so we just drop
+    // it completely as most requests do not depend on it
+    delete config.headers.host;
+
+    var isJsonRequest = !config.multipart;
+    if (config.json !== undefined) {
+      isJsonRequest = config.json;
+    }
+
     switch (method.toUpperCase()) {
         case 'DELETE':
-            return del(uri, config, !config.multipart);
+            return del(uri, config, isJsonRequest);
         case 'POST':
-            return post(uri, config, !config.multipart);
+            return post(uri, config, isJsonRequest);
         case 'PUT':
-            return put(uri, config, !config.multipart);
+            return put(uri, config, isJsonRequest);
         case 'PATCH':
-            return patch(uri, config, !config.multipart);
+            return patch(uri, config, isJsonRequest);
         case 'GET':
-            return get(uri, config, !config.multipart);
+            return get(uri, config, isJsonRequest);
         default:
             logger.warn('Method not specified');
-            return get(uri, config, !config.multipart);
+            return get(uri, config, isJsonRequest);
     }
     return post(uri, config);
 

--- a/app/src/services/dispatcherService.js
+++ b/app/src/services/dispatcherService.js
@@ -47,8 +47,7 @@ class DispatcherService {
                 let url = yield DispatcherService.buildUrl(parsedUrl.pathname, endpoint.path, service);
                 configRequest = {
                     uri: endpoint.baseUrl + url,
-                    method: endpoint.method,
-                    json: true
+                    method: endpoint.method
                 };
                 logger.debug('Create request to %s', endpoint.baseUrl + url);
                 if (endpoint.method === 'POST' || endpoint.method === 'PATCH' || endpoint.method === 'PUT') {
@@ -68,12 +67,11 @@ class DispatcherService {
             }
             return requests;
         } else  {
-
             logger.debug('Redirect to old API');
             configRequest = {
                 uri: config.get('oldAPI.url') + sourceUrl,
                 method: sourceMethod,
-                json: true
+                json: false
             };
             if (headers) {
                 logger.debug('Adding headers');

--- a/app/test/unit/services/dispatcherService.test.js
+++ b/app/test/unit/services/dispatcherService.test.js
@@ -41,7 +41,6 @@ describe('Distpatcher service', function () {
             let request = requests[0];
             request.should.have.property('uri');
             request.should.have.property('method');
-            request.should.have.property('json');
             request.method.should.have.equal(service.endpoints[0].method);
             request.uri.should.have.equal(service.endpoints[0].baseUrl + service.endpoints[0].path);
         });

--- a/config/dev.json
+++ b/config/dev.json
@@ -15,6 +15,6 @@
         "port": 32768
     },
     "oldAPI":{
-        "url":"https://testingadrianapi-dot-gfw-apis.appspot.com"
+        "url":"https://staging.api-staging.globalforestwatch.org"
     }
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -15,6 +15,6 @@
         "host": null
     },
     "oldAPI":{
-        "url":"https://testingadrianapi-dot-gfw-apis.appspot.com"
+        "url":"https://staging.api-staging.globalforestwatch.org"
     }
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -15,6 +15,6 @@
         "host": null
     },
     "oldAPI":{
-        "url":"https://testingadrianapi-dot-gfw-apis.appspot.com"
+        "url":"https://staging.api-staging.globalforestwatch.org"
     }
 }


### PR DESCRIPTION
The old API is unable to handle JSON requests, so we manually disable
it, regardless of whether or not the request is multi-part.
